### PR TITLE
Depend on perl v5.12 not v5.120

### DIFF
--- a/META.json
+++ b/META.json
@@ -43,7 +43,7 @@
       "runtime" : {
          "requires" : {
             "Getopt::Long" : "2.24",
-            "perl" : "5.12"
+            "perl" : "v5.12"
          }
       },
       "test" : {


### PR DESCRIPTION
Perl versions are weird - http://blogs.perl.org/users/grinnz/2018/04/a-guide-to-versions-in-perl.html

5.12 actually means v5.120. Either write v5.12 or 5.12.0 to actually depend on the right version.

$ perl -E 'say version->parse($_)->normal for qw/5.12 5.12.0 v5.12/'
v5.120.0
v5.12.0
v5.12.0